### PR TITLE
Skip SM patch when luma version 9.0 and higher is detected

### DIFF
--- a/source/firmware.c
+++ b/source/firmware.c
@@ -244,6 +244,12 @@ Result	bnInitParamsByFirmware(void)
         else 
             goto unsupported;
 	}
+
+	s64 out;
+	svcGetSystemInfo(&out, 0x1000, 0);
+	u8 major = GET_VERSION_MAJOR((u32)out);
+	if (major >= 9) bnConfig->SMPatchAddr = 0;
+
 	bnConfig->requireKernelHax = 0;
     return (0);
 unsupported:

--- a/source/memory_functions.c
+++ b/source/memory_functions.c
@@ -78,6 +78,7 @@ error:
 
 u32     patchRemoteProcess(u32 pid, u32 addr, u8 *buf, u32 len)
 {
+    if (addr == 0) return 0;
     u32     hProcess;
     u32     ret;
 


### PR DESCRIPTION
As of upcoming Luma version 9.0, the SM module is entirely replaced by @TuxSH's SM reimplementation. This reimplementation does not have the SM permission checks, which BootNTR typically patches out in order for NTR to run properly. However, as BootNTR expects the regular SM module, it errors or crashes when trying to patch the reimplementation.

This PR modifies the behavior of patchRemoteProcess slightly to not patch the process if the patch address is 0, and takes advantage of Luma's extended svcGetSystemInfo() to determine the Luma version (this returns 0 on non-Luma systems, so this shouldn't break compatibility). 