### PR TITLE
Fixed info type value to get Luma3DS version

### DIFF
--- a/source/firmware.c
+++ b/source/firmware.c
@@ -246,7 +246,7 @@ Result	bnInitParamsByFirmware(void)
 	}
 
 	s64 out;
-	svcGetSystemInfo(&out, 0x1000, 0);
+	svcGetSystemInfo(&out, 0x10000, 0);
 	u8 major = GET_VERSION_MAJOR((u32)out);
 	if (major >= 9) bnConfig->SMPatchAddr = 0;
 


### PR DESCRIPTION
Address 0x1000 doesn't return Luma3DS version, so the condition always fails to apply no matter the version.